### PR TITLE
Fix identification and sizes

### DIFF
--- a/data/prototypes.json
+++ b/data/prototypes.json
@@ -912,7 +912,7 @@
       },
       {
         "name": "BaseAddress",
-        "type": "PVOID",
+        "type": "PVOID *",
         "in": true,
         "out": true,
         "optional": false
@@ -926,7 +926,7 @@
       },
       {
         "name": "RegionSize",
-        "type": "PULONG",
+        "type": "PSIZE_T",
         "in": true,
         "out": true,
         "optional": false
@@ -1166,14 +1166,14 @@
       },
       {
         "name": "BaseAddress",
-        "type": "PVOID",
+        "type": "PVOID *",
         "in": true,
         "out": true,
         "optional": false
       },
       {
         "name": "RegionSize",
-        "type": "PULONG",
+        "type": "PSIZE_T",
         "in": true,
         "out": true,
         "optional": false
@@ -2314,14 +2314,14 @@
       },
       {
         "name": "NumberOfBytesToWrite",
-        "type": "ULONG",
+        "type": "SIZE_T",
         "in": true,
         "out": false,
         "optional": false
       },
       {
         "name": "NumberOfBytesWritten",
-        "type": "PULONG",
+        "type": "PSIZE_T",
         "in": false,
         "out": true,
         "optional": true
@@ -2470,14 +2470,14 @@
       },
       {
         "name": "BufferSize",
-        "type": "ULONG",
+        "type": "SIZE_T",
         "in": true,
         "out": false,
         "optional": false
       },
       {
         "name": "NumberOfBytesRead",
-        "type": "PULONG",
+        "type": "PSIZE_T",
         "in": false,
         "out": true,
         "optional": true
@@ -3054,14 +3054,14 @@
       },
       {
         "name": "BaseAddress",
-        "type": "PVOID",
+        "type": "PVOID *",
         "in": true,
         "out": true,
         "optional": false
       },
       {
         "name": "RegionSize",
-        "type": "PULONG",
+        "type": "PSIZE_T",
         "in": true,
         "out": true,
         "optional": false
@@ -15613,14 +15613,14 @@
       },
       {
         "name": "BaseAddress",
-        "type": "PVOID",
+        "type": "PVOID *",
         "in": true,
         "out": false,
         "optional": false
       },
       {
         "name": "NumberOfBytesToUnlock",
-        "type": "PULONG",
+        "type": "PSIZE_T",
         "in": true,
         "out": false,
         "optional": false

--- a/syswhispers.py
+++ b/syswhispers.py
@@ -266,7 +266,7 @@ class SysWhispers(object):
             if 'Windows 8' in compatible_versions:
                 for build in self.version_syscall_map(function_name)['Windows 8']:
                     if isinstance(jmespath.search(build['jmespath'], self.syscall_numbers), int):
-                        code += '\tcmp dword ptr [rax+11ch], 2\n'
+                        code += f'\tcmp dword ptr [rax+11ch], {build["version"][2]}\n'
                         code += f'\tje  {function_name}_SystemCall_{build["version"].replace(".", "_")}\n'
             code += f'\tjmp {function_name}_SystemCall_Unknown\n'
 
@@ -276,7 +276,7 @@ class SysWhispers(object):
             code += '; Check build number for Windows Vista.\n'
             for build in self.version_syscall_map(function_name)['Windows Vista']:
                 if jmespath.search(build['jmespath'], self.syscall_numbers):
-                    code += f'\tcmp dword ptr [rax+120h], {build["version"].split(".")[-1]}\n'
+                    code += f'\tcmp word ptr [rax+120h], {build["version"].split(".")[-1]}\n'
                     code += f'\tje  {function_name}_SystemCall_{build["version"].replace(".", "_")}\n'
             code += f'\tjmp {function_name}_SystemCall_Unknown\n'
 
@@ -286,7 +286,7 @@ class SysWhispers(object):
             code += '; Check build number for Windows 7.\n'
             for build in self.version_syscall_map(function_name)['Windows 7']:
                 if jmespath.search(build['jmespath'], self.syscall_numbers):
-                    code += f'\tcmp dword ptr [rax+120h], {build["version"].split(".")[-1]}\n'
+                    code += f'\tcmp word ptr [rax+120h], {build["version"].split(".")[-1]}\n'
                     code += f'\tje  {function_name}_SystemCall_{build["version"].replace(".", "_")}\n'
             code += f'\tjmp {function_name}_SystemCall_Unknown\n'
 
@@ -296,7 +296,7 @@ class SysWhispers(object):
             code += '; Check build number for Windows 10.\n'
             for build in self.version_syscall_map(function_name)['Windows 10']:
                 if jmespath.search(build['jmespath'], self.syscall_numbers):
-                    code += f'\tcmp dword ptr [rax+120h], {build["version"].split(".")[-1]}\n'
+                    code += f'\tcmp word ptr [rax+120h], {build["version"].split(".")[-1]}\n'
                     code += f'\tje  {function_name}_SystemCall_{build["version"].replace(".", "_")}\n'
             code += f'\tjmp {function_name}_SystemCall_Unknown\n'
 


### PR DESCRIPTION
see https://github.com/jthuraisamy/SysWhispers/pull/3 for pull to original repository, info below for completeness.

This pull request makes the following fixes:

- Update build version compare to use word instead of dword. Current compare fails if OSCSDVersion is not 0 (reference https://www.geoffchappell.com/studies/windows/win32/ntdll/structs/peb/index.htm)

  -  This hit for me on windows 7

- Update Windows 8 / 2012 to use minor version 3 instead of 2 for 8.1 / 2012 r2

- Update the RegionSize of various VirtualMemory Functions to PSIZE_T instead of PULONG. Size mismatch causes functions to fail depending on how the register is extended.

   - (Reference https://github.com/reactos/reactos/blob/master/sdk/include/ndk/mmfuncs.h)

- Uses PVOID * in the updated VirtualMemory functions to match reactos and make it more clear what is expected to be passed.

An example project using the output of SysWhisper before and after these changes is available here https://github.com/freefirex/Sys_fix_demo